### PR TITLE
Added fingerprint _TZ3000_402vrq2i

### DIFF
--- a/drivers/zigbee-tuya-button/fingerprints.yaml
+++ b/drivers/zigbee-tuya-button/fingerprints.yaml
@@ -329,6 +329,10 @@ zigbeeManufacturer:
     deviceLabel: Zigbee Tuya 4 Button
     manufacturer: _TZ3000_et7afzxz
     model: TS004F
+  - id: _TZ3000_402vrq2i/TS004F
+    deviceLabel: Zigbee Tuya 1 Button Rotation
+    manufacturer: _TZ3000_402vrq2i
+    model: TS004F
     deviceProfileName: zigbee-tuya-button-4
   - id: Legrand/TS0042
     deviceLabel: Legrand 2 Button


### PR DESCRIPTION
Added fingerprint for _TZ3000_402vrq2i. Device was  found on Aliexpress listing: 1005007720682666 and similar.

Profile might not be full compatible as it does have rotation but if it works its better than the paperweight it is right now.