### PR TITLE
Update init.lua

### DIFF
--- a/drivers/zigbee-tuya-button/src/init.lua
+++ b/drivers/zigbee-tuya-button/src/init.lua
@@ -22,7 +22,6 @@ local knob_models = {
   ["_TZ3000_402vrq2i"] = true,
   ["_TZ3000_abrsvsou"] = true,
   ["_TZ3000_4fjiwweb"] = true,
-  ["_TZ3000_xr7itfxq"] = true,
   ["_TZ3000_qja6nq5z"] = true
 }
 


### PR DESCRIPTION
Hi obmaz.

Thank you, as always, for maintaining this project so well. Your work has made integration much smoother, and I truly appreciate all the support the project has provided.

During recent testing, **I found that the _TZ3000_xr7itfxq model was registered as a knob-type device,** which caused it to be recognized differently from the usual Zigbee 2-button devices during pairing. This pull request includes a fix to handle this specific model appropriately.

When I initially submitted the device support request, I should have provided a clearer description of the product. However, since it was my first time contributing, I wasn't fully familiar with the process, which led to this issue.

Currently, one button is recognized and partially working, but I believe this fix will help prevent confusion or potential issues for other users going forward.

Please feel free to review it when you have time, and let me know if there's anything I should improve or change. Again, thank you for your continued dedication to this great project!

Best regards,