### PR TITLE
Fix: resolve malfunctioning behavior of _TZ3210_3ulg9kpo

### DIFF
--- a/drivers/zigbee-tuya-button/src/tuya-EF00/init.lua
+++ b/drivers/zigbee-tuya-button/src/tuya-EF00/init.lua
@@ -79,6 +79,7 @@ end
 local ZIGBEE_TUYA_BUTTON_EF00_FINGERPRINTS = {
   { mfr = "_TZE200_zqtiam4u", model = "TS0601" },
   { mfr = "_TZE204_mpg22jc1", model = "TS0601" },
+  { mfr = "_TZ3210_3ulg9kpo", model = "TS0021" },
 }
 
 local is_tuya_ef00 = function(opts, driver, device)


### PR DESCRIPTION
This PR requests merging the fixes I made in my forked edge driver.
These changes ensure correct operation of _TZ3210_3ulg9kpo

In addition, can I add another fingerprint of the same appearance?

```
- id: TELINK/TLSR82xx
deviceLabel: Zigbee Tuya 2 Button
manufacturer: TELINK
model: TLSR82xx
deviceProfileName: zigbee-tuya-button-2
```